### PR TITLE
Adjustment to make hubspot work with OAuth2

### DIFF
--- a/lib/omniauth/strategies/hubspot.rb
+++ b/lib/omniauth/strategies/hubspot.rb
@@ -13,7 +13,6 @@ module OmniAuth
         token_url: 'oauth/v1/token',
         auth_scheme: :request_body
       }
-
     end
   end
 end


### PR DESCRIPTION
Updating strategy to make our hubspot integration work with the most recent faraday/omniauth versions we will have in `smile-core`

### Manual Testing
- Tried connecting to hubspot using the new updated omniauth/faraday dependencies and confirmed that the integration broke with an `unknown_client_id` error.

- Pointed my local `smile-core` to this branch and ensured connecting to hubspot works after the change.
<img width="1523" alt="Screen Shot 2023-05-05 at 12 05 07" src="https://user-images.githubusercontent.com/12715554/236495930-f7ee53c5-0e32-4c1a-ad38-a2b20c0a9d0c.png">
